### PR TITLE
fix: sending query params

### DIFF
--- a/addons/better-http/client.gd
+++ b/addons/better-http/client.gd
@@ -7,7 +7,7 @@ var _default_headers: PackedStringArray
 var _scene: SceneTree
 var _max_redirects: int = 5
 
-func _init(node: Node, base_url: URL):
+func _init(node: Node, base_url: BetterHTTPURL):
 	self._scene = node.get_tree()
 	self._base_url = base_url
 
@@ -27,7 +27,7 @@ func dispatch(method: HTTPClient.Method, path: String) -> BetterHTTPRequest:
 	req._headers = self._default_headers.slice(0)
 	req._max_redirects = self._max_redirects
 	req._url = self._base_url.join(path)
-
+	
 	# needed for some sites that use a proxy of some sort
 	req.header("host", self._base_url.http_host())
 	req.header("connection", "keep-alive")
@@ -48,4 +48,3 @@ func http_patch(path: String = "/") -> BetterHTTPRequest:
 
 func http_delete(path: String = "/") -> BetterHTTPRequest:
 	return self.dispatch(HTTPClient.METHOD_DELETE, path)
-

--- a/addons/better-http/url.gd
+++ b/addons/better-http/url.gd
@@ -34,7 +34,7 @@ static func parse_path(url: String) -> BetterHTTPURL:
 		query = path.substr(query_delim + 1)
 		path = path.substr(0, query_delim)
 
-	var u = URL.new()
+	var u = BetterHTTPURL.new()
 
 	u.path = path
 	u.query = query
@@ -52,7 +52,7 @@ static func parse(url: String) -> BetterHTTPURL:
 	var path_delim: int = url.find("/")
 	var port_delim: int
 
-	var u = URL.parse_path(url)
+	var u = BetterHTTPURL.parse_path(url)
 
 	var has_port: bool
 	var host_length: int
@@ -84,7 +84,7 @@ static func parse(url: String) -> BetterHTTPURL:
 	return u
 
 func clone() -> BetterHTTPURL:
-	var url = URL.new()
+	var url = BetterHTTPURL.new()
 	
 	url.host = self.host
 	url.port = self.port
@@ -100,7 +100,7 @@ func join(path: String) -> BetterHTTPURL:
 
 func join_mut(path: String) -> BetterHTTPURL:
 	var other = BetterHTTPURL.parse_path(path)
-
+	
 	# merge path
 	match [self.path.ends_with("/"), other.path.begins_with("/")]:
 		[true, true]:
@@ -119,8 +119,16 @@ func join_mut(path: String) -> BetterHTTPURL:
 	# overwrite hash if given
 	if not other.hash.is_empty():
 		self.hash = other.hash
-
+	
 	return self
+
+func stringify_path() -> String:
+	var url := self.path
+	
+	if query != "":
+		url += "?" + self.query
+		
+	return url
 
 func stringify() -> String:
 	var url: String = "http" + ("s" if self.use_ssl else "") + "://" + self.http_host() + self.path
@@ -144,4 +152,3 @@ func http_host() -> String:
 # returns true if the old and new URLs represent different addresses
 func addr_eq(other: BetterHTTPURL) -> bool:
 	return self.host == other.host and self.port == other.port and self.use_ssl == other.use_ssl
-


### PR DESCRIPTION
Added a new method stringify_path() to include query params when sending an HTTP request, and fixed all broken class names.